### PR TITLE
Change email address regex to be less naive

### DIFF
--- a/lib/normailize/email_address.rb
+++ b/lib/normailize/email_address.rb
@@ -18,7 +18,14 @@ module Normailize
     attr_reader :address, :username, :domain
 
     # Private: Simple regex to validate format of an email address
-    EMAIL_ADDRESS_REGEX = /\A.+\@.+\..+\z/
+    #
+    # We're deliberately ignoring a whole range of special and restricted chars
+    # for the sake of simplicity. This should match 99.99% of all the email
+    # addresses out there. If you allow comments (parentheses enclosed) in the
+    # local or domain part of your email addresses, make sure to strip them for
+    # normalization purposes. For '@' in the local part to be allowed, split
+    # local and domain part at the _last_ occurrence of the @-symbol.
+    EMAIL_ADDRESS_REGEX = /\A([a-z0-9_\-][a-z0-9_\-\+\.]{,62})?[a-z0-9_\-]@(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)+[a-z]{2,}\z/i
 
     # Public: Class initializer
     #

--- a/spec/lib/normailize/email_address_spec.rb
+++ b/spec/lib/normailize/email_address_spec.rb
@@ -13,7 +13,15 @@ describe Normailize::EmailAddress do
     context 'when email address is not valid' do
       it 'raises an exception' do
         expect do
-          Normailize::EmailAddress.new('not an email address')
+          Normailize::EmailAddress.new('not an @email address. sorry!')
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when email address is technically valid, but we do not accept it' do
+      it 'raises an exception' do
+        expect do
+          Normailize::EmailAddress.new('" fairly.@.unusual.example.com"(&a_comment_making_it_extralong!)@[IPv6:2001:db8:23:::42]')
         end.to raise_error(ArgumentError)
       end
     end
@@ -81,7 +89,7 @@ describe Normailize::EmailAddress do
           'JoHn@live.com'            => 'jOhN@live.com',
           'john+lol@live.com'        => 'john+wtf@live.com',
           'John+lol+wtf@live.com'    => 'jOhn+lol@live.com',
-          'john@hotmail.com'         => 'john@hotmail.com',
+          'john@hotmail.com'         => 'john@hotmail.com'
         }
 
         emails.each_pair do |e1, e2|


### PR DESCRIPTION
This commit marries a little sanity with a wee bit of strictness and a twist of RFC compliance to the email address regex check.
Yes, this is a 3-way marriage.
